### PR TITLE
Add API gateway with Nginx and Docker Compose

### DIFF
--- a/Back/api-gateway/docker-compose.yml
+++ b/Back/api-gateway/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  api-gateway:
+    image: nginx:latest
+    container_name: api-gateway
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    # This ensures that the container will always restart unless explicitly stopped, which is useful for maintaining service availability.
+    restart: unless-stopped

--- a/Back/api-gateway/nginx.conf
+++ b/Back/api-gateway/nginx.conf
@@ -1,0 +1,32 @@
+events {}
+
+http {
+    upstream user-service {
+        server host.docker.internal:3000;
+    }
+
+    upstream messaging-service {
+        server host.docker.internal:3001;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location /api/user/ {
+            proxy_pass http://user-service/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/message/ {
+            proxy_pass http://messaging-service/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
Introduced a new api-gateway service using Nginx, configured via docker-compose.yml. The nginx.conf routes /api/user/ and /api/message/ requests to user and messaging services respectively, enabling centralized API routing.